### PR TITLE
need to be root to write to etc/kube

### DIFF
--- a/enable-API-auditing.yml
+++ b/enable-API-auditing.yml
@@ -1,4 +1,6 @@
 - hosts: kube-master
+  become: true
+  become_user: root
   tasks:
   - name: Copy audit-pod-policy.yaml to /etc/kubernetes
     copy:


### PR DESCRIPTION
Per a bug report from @DrBuckin80918 - the ansible script fails with insufficient permissions when trying to copy to /etc/kubernetes unless we become root.

@ghobrial going to merge now so no one trips on this in the meantime, but when you're back from pto have a look here and let us know if you have a preferred solution.