### PR TITLE
removing stable repo from script

### DIFF
--- a/get_helm.sh
+++ b/get_helm.sh
@@ -235,7 +235,6 @@ testVersion
 cleanup
 
 echo "source <(helm completion bash)" >> ~/.bashrc
-helm repo add stable https://charts.helm.sh/stable
 helm repo add nginx-stable https://helm.nginx.com/stable
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo update


### PR DESCRIPTION
Removing from script as the stable repo is archived and Artifact Hub is the main source for repos